### PR TITLE
be very explicit about client binary name

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -23,7 +23,7 @@
   become: false
   get_url:
     url: "https://github.com/restic/restic/releases/download/v{{ restic_version }}/restic_{{ restic_version }}_{{ ansible_system | lower }}_{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.bz2"
-    dest: '/tmp'
+    dest: "/tmp/restic_{{ restic_version }}_{{ ansible_system | lower }}_{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.bz2"
     checksum: "sha256:{{ restic_checksum }}"
   delegate_to: localhost
   run_once: true


### PR DESCRIPTION
Currently filename is determined by content-disposition header or extracted filename from the url (just the way get_url works, see: https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/net_tools/basics/get_url.py#L487).

I'm not sure why, but for me the extraction from the content-disposition header fails every time and filename is extracted from the URL, leading to a different filename then what is used in https://github.com/paulfantom/ansible-restic/blob/master/tasks/install.yml#L34

By explicitly setting the filename it is possible to ensure that the decompression works.
