### PR TITLE
Optionally discard stdout of preconfigured cron jobs

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,8 @@ restic_install_path: '/usr/local/bin'
 
 restic_initialize_repos: true
 
+restic_discard_cron_stdout: false
+
 restic_repos: []
 # restic_repos:
 # - name: s3-example

--- a/templates/restic.cron.j2
+++ b/templates/restic.cron.j2
@@ -20,11 +20,11 @@ RESTIC_PASSWORD={{ item.password | trim | quote }}
 {% if item.retention.weekly is defined %} --keep-weekly {{ item.retention.weekly }}{% endif -%}
 {% if item.retention.monthly is defined %} --keep-monthly {{ item.retention.monthly }}{% endif -%}
 {% if item.retention.yearly is defined %} --keep-yearly {{ item.retention.yearly }}{% endif -%}
-{% if item.retention.tags is defined %} --keep-tag {% for tag in item.retention.tags %}{{ tag }}{% if not loop.last %},{% endif %}{% endfor %}{% endif -%}
+{% if item.retention.tags is defined %} --keep-tag {% for tag in item.retention.tags %}{{ tag }}{% if not loop.last %},{% endif %}{% endfor %}{% endif -%}{% if restic_discard_cron_stdout %} > /dev/null{% endif %}
 ;{% endif %}
 {% if item.check | default(true) -%}
 # Check repository
-{{ item.check_time | default('17 4 * * *') }} {{ restic_user }} restic check
+{{ item.check_time | default('17 4 * * *') }} {{ restic_user }} restic check{% if restic_discard_cron_stdout %} > /dev/null{% endif %}
 {%- endif %}
 
 # Do an actual backup


### PR DESCRIPTION
On my servers I usually want to redirect stdout to `/dev/null` in cron jobs, so that mails will only be sent when errors occur.

This PR adds a new variable `restic_discard_cron_stdout` which adds a redirection for the `forget` and `check` cron jobs when set to `true`.