### PR TITLE
Create a home directory for the restic user

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@ restic_version: '0.8.3'
 
 restic_user: root
 restic_group: "{{ restic_user }}"
+restic_home: "/var/lib/restic"
 
 restic_install_path: '/usr/local/bin'
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -10,7 +10,8 @@
     group: "{{ restic_group }}"
     shell: /bin/false
     system: true
-    createhome: false
+    createhome: true
+    home: "{{ restic_home }}"
     state: present
   when: restic_user != 'root'
 


### PR DESCRIPTION
Restic 0.9 adds a cache feature. The location defaults to `$HOME/.cache/restic`. 

This PR adds a new variable `restic_home` containing the path for the users home directory. Ansible will now create a home directory for the Restic user and the cache will be enabled.