### PR TITLE
fix for TASK [paulfantom.restic : Get checksum for 386 architecture]

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,6 +1,6 @@
 ---
 go_arch_map:
-  i386: 386
+  i386: "386"
   x86_64: amd64
   aarch64: arm64
   armv7l: arm


### PR DESCRIPTION
"msg": "The conditional check '('restic_' + restic_version + '_linux_' + (go_arch_map[ansible_architecture] | default(ansible_architecture)) + '.bz2') in item' failed. The error was: Unexpected templating type error occurred on ({% if ('restic_' + restic_version + '_linux_' + (go_arch_map[ansible_architecture] | default(ansible_architecture)) + '.bz2') in item %} True {% else %} False {% endif %}): coercing to Unicode: need string or buffer, int found\n\nThe error appears to have been in '/home/guillermo/src/ansible/roles/paulfantom.restic/tasks/preflight.yml': line 22, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: \"Get checksum for {{ go_arch_map[ansible_architecture] | default(ansible_architecture) }} architecture\"\n  ^ here\nWe could be wrong, but this one looks like it might be an issue with\nmissing quotes.  Always quote template expression brackets when they\nstart a value. For instance:\n\n    with_items:\n      - {{ foo }}\n\nShould be written as:\n\n    with_items:\n      - \"{{ foo }}\"\n"
}