### PR TITLE
added architecture to temp restic executable file

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -32,16 +32,16 @@
 
 - name: Decompress the binary
   become: false
-  shell: "bzip2 -dc /tmp/restic_{{ restic_version }}_{{ ansible_system | lower }}_{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.bz2 > /tmp/restic_{{ restic_version }}"
+  shell: "bzip2 -dc /tmp/restic_{{ restic_version }}_{{ ansible_system | lower }}_{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.bz2 > /tmp/restic_{{ restic_version }}_{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}"
   args:
-    creates: "/tmp/restic_{{ restic_version }}"
+    creates: "/tmp/restic_{{ restic_version }}_{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}"
   delegate_to: localhost
   run_once: true
   check_mode: false
 
 - name: Propagate restic binary
   copy:
-    src: "/tmp/restic_{{ restic_version }}"
+    src: "/tmp/restic_{{ restic_version }}_{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}"
     dest: '{{ restic_install_path }}/restic'
     mode: '0750'
     owner: 'root'


### PR DESCRIPTION
Playbook is deploying amd64 to i386 machines on mixed deploy, fixed changing temp files names to account for architecture and avoid overwriting other arch files.