### PR TITLE
fiexd aws aws_access_key_id var name

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,7 +17,7 @@ restic_repos: []
 #   url: "s3:s3.amazonaws.com/bucket_name/restic"
 #   password: "dolphins"
 #   remote_credentials:
-#     aws_secret_key_id: "AWS_ACCESS_KEY_ID"
+#     aws_access_key_id: "AWS_ACCESS_KEY_ID"
 #     aws_secret_access_key: "AWS_SECRET_ACCESS_KEY"
 #   jobs:
 #     - command: 'restic backup /srv'


### PR DESCRIPTION
The name is used in templates, cron jobs fail with wrong aws credentials variables.