### PR TITLE
Removed export from template

### DIFF
--- a/templates/restic.cron.j2
+++ b/templates/restic.cron.j2
@@ -3,8 +3,8 @@
 # {{ ansible_managed }}
 SHELL=/bin/sh
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:{{ restic_install_path }} 
-export RESTIC_REPOSITORY={{ item.url | trim | quote }}
-export RESTIC_PASSWORD={{ item.password | trim | quote }}
+RESTIC_REPOSITORY={{ item.url | trim | quote }}
+RESTIC_PASSWORD={{ item.password | trim | quote }}
 {% if item.remote_credentials is defined %}
 {% for k,v in item.remote_credentials.items() %}
 export {{ k | upper }}={{ v | trim | quote }}

--- a/templates/restic.cron.j2
+++ b/templates/restic.cron.j2
@@ -7,7 +7,7 @@ RESTIC_REPOSITORY={{ item.url | trim | quote }}
 RESTIC_PASSWORD={{ item.password | trim | quote }}
 {% if item.remote_credentials is defined %}
 {% for k,v in item.remote_credentials.items() %}
-export {{ k | upper }}={{ v | trim | quote }}
+{{ k | upper }}={{ v | trim | quote }}
 {% endfor %}
 {% endif %}
 


### PR DESCRIPTION
Hello,
I removed the export from the template because it breaks Ubuntu cron files. cron will deactivate the file because its invalid. Also a export is not needed to set a environment variable in a cron file :)