### PR TITLE
Don't try to chmod or chown files under /dev

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -27,7 +27,9 @@
   with_items:
     - "{{ restic_cron_stdout_file }}"
     - "{{ restic_cron_stderr_file }}"
-  when: item != None
+  when:
+    - item != None
+    - item is not match("/dev/.*")
 
 - name: Ensure restic user can write to log files if defined
   file:
@@ -39,7 +41,9 @@
   with_items:
     - "{{ restic_cron_stdout_file }}"
     - "{{ restic_cron_stderr_file }}"
-  when: item != None
+  when:
+    - item != None
+    - item is not match("/dev/.*")
 
 - name: Download client binary
   become: false


### PR DESCRIPTION
#38 introduced a bug: when using a file as a redirect target for Cron jobs as described in the documentation, the install task will change owner and permissions of this file.

The docs recommend to use `/dev/null` when output should be discarded. The task will then change permissions on these files as well, leading to unexpected results.