### PR TITLE
Remove all run_once

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -52,7 +52,6 @@
     dest: "/tmp/restic_{{ restic_version }}_{{ ansible_system | lower }}_{{ go_arch }}.bz2"
     checksum: "sha256:{{ restic_checksum }}"
   delegate_to: localhost
-  run_once: true
   check_mode: false
 
 - name: Decompress the binary
@@ -61,7 +60,6 @@
   args:
     creates: "/tmp/restic_{{ restic_version }}_{{ go_arch }}"
   delegate_to: localhost
-  run_once: true
   check_mode: false
 
 - name: Propagate restic binary

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -11,7 +11,6 @@
     register: _latest_release
     until: _latest_release.status == 200
     retries: 5
-    run_once: true
     delegate_to: localhost
 
   - name: "Set restic version to {{ _latest_release.json.tag_name[1:] }}"
@@ -22,7 +21,6 @@
 - name: Get checksum list from github
   set_fact:
     _checksums: "{{ lookup('url', 'https://github.com/restic/restic/releases/download/v' + restic_version + '/SHA256SUMS', wantlist=True) | list }}"
-  run_once: true
   delegate_to: localhost
 
 - name: "Get checksum for {{ go_arch }} architecture"


### PR DESCRIPTION
I know you added them for a reason, but I keep running into stuff like
```
fatal: [example-host]: FAILED! => {"msg": "'_checksums' is undefined"}
```

Sadly, run_once in Ansible can sometimes mean run_never and #55 didn't fix this properly after all.