### PR TITLE
Changed checksum checking process

### DIFF
--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -19,12 +19,17 @@
   when: restic_version == "latest"
 
 - name: Get checksum list from github
-  set_fact:
-    _checksums: "{{ lookup('url', 'https://github.com/restic/restic/releases/download/v' + restic_version + '/SHA256SUMS', wantlist=True) | list }}"
-  delegate_to: localhost
+  get_url:
+      url: 'https://github.com/restic/restic/releases/download/v{{ restic_version }}/SHA256SUMS'
+      dest: /tmp/restic-{{ restic_version }}-SHA256SUMS
+
+- name: Set checksum variable
+  slurp: 
+      src: "/tmp/restic-{{ restic_version }}-SHA256SUMS"
+  register: _checksums
 
 - name: "Get checksum for {{ go_arch }} architecture"
   set_fact:
     restic_checksum: "{{ item.split(' ')[0] }}"
-  with_items: "{{ _checksums }}"
+  with_items: "{{ (_checksums.content | b64decode).split('\n') }}"
   when: "('restic_' + restic_version + '_linux_' + go_arch + '.bz2') in item"


### PR DESCRIPTION
Changed checksum checking process to prevent "NSPlaceholderDate" error
```
objc[6763]: +[__NSPlaceholderDate initialize] may have been in progress in another thread when fork() was called.
objc[6763]: +[__NSPlaceholderDate initialize] may have been in progress in another thread when fork() was called. We cannot safely call it or ignore it in the fork() child process. Crashing instead. Set a breakpoint on objc_initializeAfterForkError to debug.
```

And environment variable `export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES` workaround usage.
https://github.com/ansible/ansible/issues/32499
https://github.com/ansible/ansible/issues/31869

Now, SHA256SUMS file downloads to the /tmp, then fetching for the proper checksum.