### PR TITLE
Option to use files for in|exclusion patterns to fix "Error: command too long"

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `restic_cron_stderr_file` | null | what file to log restic errors to, null means include in mailto, use /dev/null to discard |
 | `restic_sudo_command_whitelist` | [] | whitelist of commands restic is allowed to run with sudo |
 | `restic_repos` | [] | restic repositories and cron jobs configuration. More in [defaults/main.yml](defaults/main.yml) |
+| `restic_includes_files` | [] | alternative to specifying files/dirs to backup directly in `command` in `restic_repos`. More in [defaults/main.yml](defaults/main.yml) |
+| `restic_excludes_files` | [] | alternative to specifying exclusion patterns directly in `command` in `restic_repos`. More in [defaults/main.yml](defaults/main.yml) |
 
 ## Security
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,7 @@ restic_shell: "/bin/false"
 restic_home: "/var/lib/restic"
 
 restic_install_path: '/usr/local/bin'
+restic_config_path: '/etc/restic'
 
 restic_initialize_repos: true
 
@@ -47,7 +48,14 @@ restic_repos: []
 #     b2_account_id: "B2_ACCOUNT_ID"
 #     b2_account_key: "B2_ACCOUNT_KEY"
 #   jobs:
-#     - command: 'restic backup /var'
+#     # Set up `restic_includes_files` and `restic_excludes_files` (see below)
+#     # to avoid specifying all the excludes/includes in the crontab command,
+#     # which has 999 symbols limit, then reference these files in your `command`
+#     # with --files-from and --exclude-file:
+#     - command: >-
+#         restic --exclude "*something*" backup /var
+#         --files-from {{ restic_config_path }}/includes-b2-bucketname
+#         --exclude-file {{ restic_config_path }}/excludes-b2-bucketname
 #       at: '0 4  * * *'
 #     - command: 'restic backup /home'
 #       at: '0 3  * * *'
@@ -59,3 +67,17 @@ restic_repos: []
 #     - command: "openvpn -c /etc/myvpn.ovpn && ionice -c2 -n7 nice -n5 restic backup /home && curl -fsS --retry 4 https://hc-ping.com/XXXXXX-.." # adjusted niceness I/O priority and use pre and post command
 #       at: "{{ 60 |random(seed=inventory_hostname) }} 4  * * *" # use random minutes based on inventory hostname
 #   check: false # don't check repository from client. Instead, you can check directly from the server.
+
+restic_includes_files: []
+# restic_includes_files:
+#   - filename: includes-b2-bucketname
+#     includes: |
+#       /etc
+#       /usr/local/etc
+
+restic_excludes_files: []
+# restic_excludes_files:
+#   - filename: excludes-b2-bucketname
+#     excludes: |
+#       **/tmp
+#       **/log

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -20,6 +20,34 @@
     state: 'directory'
     path: '{{ restic_install_path }}'
 
+- name: Ensure restic configuration directory exist
+  file:
+    state: 'directory'
+    path: '{{ restic_config_path }}'
+    owner: '{{ restic_user }}'
+    group: '{{ restic_group }}'
+    mode: 0750
+
+- name: Deploy configs with includes
+  copy:
+    content: "{{ item.includes }}"
+    dest: "{{ restic_config_path }}/{{ item.filename }}"
+    owner: "{{ restic_user }}"
+    group: "{{ restic_group }}"
+    mode: '0640'
+  with_items: '{{ restic_includes_files }}'
+  no_log: true
+
+- name: Deploy configs with excludes
+  copy:
+    content: "{{ item.excludes }}"
+    dest: "{{ restic_config_path }}/{{ item.filename }}"
+    owner: "{{ restic_user }}"
+    group: "{{ restic_group }}"
+    mode: '0640'
+  with_items: '{{ restic_excludes_files }}'
+  no_log: true
+
 - name: Ensure restic user can write to log dirs if defined
   file:
     state: 'directory'


### PR DESCRIPTION
We only could include/exclude files from backup by passing them to the
restic binary as an option inline in `restic_repos.command`.
When the number of in/exclude patterns grows, executed command in cron file
truncated at 999th symbol with error message "Error: command too long":
https://serverfault.com/questions/546342/crontab-maximum-command-length/736010#736010

This PR allows specifying include/exclude files with their contents in
`defaults/main.yml`, then these files will be created in `tasks/install.yml`.
Then you can reference these files in your `restic_repos.command` like this:
```bash
restic --files-from {{ restic_config_path }}/includes \
  --exclude-file {{ restic_config_path }}/excludes backup
```

It will make the command executed by cron daemon much shorter thus avoiding
999 symbols problem.