### PR TITLE
Restic 0.9.6 has been out for a while

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 
 | Name           | Default Value | Description                        |
 | -------------- | ------------- | -----------------------------------|
-| `restic_version` | 0.9.5 | restic package version. Also accepts latest as parameter. |
+| `restic_version` | 0.9.6 | restic package version. Also accepts latest as parameter. |
 | `restic_user` | "root" | system user to run restic |
 | `restic_group` | "root" | system group to run restic |
 | `restic_shell` | "/bin/false" | the shell for the restic user, change this if you want to be able to su to it |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-restic_version: '0.9.5'
+restic_version: '0.9.6'
 
 restic_user: root
 restic_group: "{{ restic_user }}"


### PR DESCRIPTION
Update README.md and the defaults variable.